### PR TITLE
Case matters in Linux filesystems where it does not on Windows

### DIFF
--- a/Logger.cs
+++ b/Logger.cs
@@ -6,7 +6,7 @@ namespace ArmorRepair
     class Logger
     {
 
-        public const string path = "mods/ArmorRepair/Log.txt";
+        public const string path = "Mods/ArmorRepair/Log.txt";
 
         public Logger()
         {


### PR DESCRIPTION
Filesystem case on Linux matters whereas on Windows it does not. This is my attempt to make Roguetech work on the Linux version of Battletech with the fewest (preferably none) changes required to do so.

This negates the need to make the mods -> Mods symblink.